### PR TITLE
restart-only for autoscaler

### DIFF
--- a/python/ray/autoscaler/autoscaler.py
+++ b/python/ray/autoscaler/autoscaler.py
@@ -504,14 +504,17 @@ class StandardAutoscaler(object):
             return
         if self.files_up_to_date(node_id):
             return
-        if self.config.get("no_restart", False) and \
-                self.num_successful_updates.get(node_id, 0) > 0:
+        successful_updated = self.num_successful_updates.get(node_id, 0) > 0
+        if succesful_updated and self.config.get("restart_only", False):
+            init_commands = self.config["worker_start_ray_commands"]
+        elif succesful_updated and self.config.get("no_restart", False):
             init_commands = (self.config["setup_commands"] +
                              self.config["worker_setup_commands"])
         else:
             init_commands = (self.config["setup_commands"] +
                              self.config["worker_setup_commands"] +
                              self.config["worker_start_ray_commands"])
+
         updater = self.node_updater_cls(
             node_id,
             self.config["provider"],

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -372,6 +372,12 @@ def stop():
     help=("Whether to skip restarting Ray services during the update. "
           "This avoids interrupting running jobs."))
 @click.option(
+    "--restart-only",
+    is_flag=True,
+    default=False,
+    help=("Whether to skip running setup commands and only restart Ray. "
+          "This cannot be used with 'no-restart'."))
+@click.option(
     "--min-workers",
     required=False,
     type=int,
@@ -387,10 +393,14 @@ def stop():
     is_flag=True,
     default=False,
     help=("Don't ask for confirmation."))
-def create_or_update(cluster_config_file, min_workers, max_workers, no_restart,
-                     yes):
+def create_or_update(cluster_config_file, min_workers, max_workers,
+                     no_restart, restart_only, yes):
+    # NOTE(rliaw): This check should probably be done in click
+    if restart_only or no_restart:
+        assert restart_only != no_restart, "Cannot set both 'restart_only' " \
+            "and 'no_restart' at the same time!"
     create_or_update_cluster(cluster_config_file, min_workers, max_workers,
-                             no_restart, yes)
+                             no_restart, restart_only, yes)
 
 
 @click.command()


### PR DESCRIPTION
Add option to start ray without needing to run all setup commands

`ray up CLUSTER --restart-only`
Adds also a check to avoid `no-restart` and `restart-only` conflicts.